### PR TITLE
Test PRT Label

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -220,7 +220,7 @@ def test_negative_global_registration_without_ak(module_target_sat):
     """
     with pytest.raises(HTTPError) as context:
         module_target_sat.api.RegistrationCommand().create()
-    assert 'Missing activation key!' in context.value.response.text
+    assert 'Test' in context.value.response.text
 
 
 def test_negative_capsule_without_registration_enabled(


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->